### PR TITLE
Aggiunto paramentro Position 

### DIFF
--- a/classes/occookielaw.php
+++ b/classes/occookielaw.php
@@ -32,10 +32,17 @@ class OCCookieLaw
                 $info = $ini->variable( 'AlertSettings', 'InfoButtonText' );
             }
 
+            $position = "top";
+            if ( $ini->hasVariable( 'AlertSettings', 'Position' ) )
+            {
+                $position = $ini->variable( 'AlertSettings', 'Position' );
+            }
+
             $tpl = eZTemplate::factory();
             $tpl->setVariable( 'message', $message );
             $tpl->setVariable( 'dismiss_button', $dismiss );
             $tpl->setVariable( 'info_button', $info );
+            $tpl->setVariable( 'position', $position );
 
             return $tpl->fetch( 'design:inject_in_page_layout.tpl' );
         }

--- a/design/standard/javascript/cookiechoices.js
+++ b/design/standard/javascript/cookiechoices.js
@@ -31,12 +31,8 @@
     var dismissLinkId = 'cookieChoiceDismiss';
 
     function _createHeaderElement(cookieText, dismissText, linkText, linkHref) {
-      var butterBarStyles = 'position:fixed;width:100%;background-color:#666;color: #fff;font-weight: bold;' +
-          'margin:0; left:0; top:0;padding:11px;z-index:1000;text-align:center;';
-
       var cookieConsentElement = document.createElement('div');
       cookieConsentElement.id = cookieConsentId;
-      cookieConsentElement.style.cssText = butterBarStyles;
       cookieConsentElement.appendChild(_createConsentText(cookieText));
 
       if (!!linkText && !!linkHref) {

--- a/design/standard/templates/inject_in_page_layout.tpl
+++ b/design/standard/templates/inject_in_page_layout.tpl
@@ -1,4 +1,6 @@
 <script src="{'javascript/cookiechoices.js'|ezdesign(no)}"></script>
+<style>#cookieChoiceInfo{ldelim}position:fixed;width:100%;background-color:#666;color: #fff;font-weight: bold; margin:0; left:0; padding:11px;z-index:1000;text-align:center; {$position}:0;{rdelim}</style>
+
 {literal}
 <script>
     document.addEventListener('DOMContentLoaded', function(event) {

--- a/settings/cookielaw.ini
+++ b/settings/cookielaw.ini
@@ -5,6 +5,9 @@
 #DismissButtonText=
 #InfoButtonText
 
+#il valore di default è top e posiziona la barra dei cookies al top, altrimenti valorizzare a bottom
+#Position=bottom
+
 [UriExcludeList]
 # Se enabled, non inietta il template se l'utente corrente è loggato
 #ExcludeUserLoggedIn=disabled


### PR DESCRIPTION
Aggiunto parametro Position in cookielaw.ini per scegliere se la barra appare in alto (top) o in basso (bottom) di default il valore è top per retro compatibilità, se il parametro Position non è valorizzato o non esiste, il valore è comunque top. 